### PR TITLE
fix: surface unreadable Queue API replies as a user error instead of an internal error

### DIFF
--- a/src/component.py
+++ b/src/component.py
@@ -81,8 +81,9 @@ class Component(ComponentBase):
             # job, and retrying it would start a second one.
             raise UserException(
                 f"Could not read the Keboola Queue API reply when starting the job of component "
-                f"'{component_id}'. This is usually a temporary problem, re-run the configuration. "
-                f"\n\n{response_exc}"
+                f"'{component_id}'. The job may or may not have been started. Check the job list "
+                f"for '{component_id}' before running this configuration again, so that the job is "
+                f"not started twice.\n\n{response_exc}"
             ) from response_exc
         except KeboolaClientQueueV2Exception as v2_exc:
             try:
@@ -109,8 +110,10 @@ class Component(ComponentBase):
             # Not routed to the Queue V1 fallback on purpose: a job that the V1 API cannot report on
             # would otherwise be treated as if its status had been read successfully.
             raise UserException(
-                f"Could not read the Keboola Queue API reply while monitoring job ID {job_id}. "
-                f"This is usually a temporary problem, re-run the configuration.\n\n{response_exc}"
+                f"Could not read the Keboola Queue API reply while monitoring job ID {job_id}. That "
+                f"job is unaffected and still runs to completion. Check its result in the job list "
+                f"rather than running this configuration again, which would start a second job."
+                f"\n\n{response_exc}"
             ) from response_exc
         except KeboolaClientQueueV2Exception as v2_exc:
             try:

--- a/src/component.py
+++ b/src/component.py
@@ -13,7 +13,7 @@ from kbcstorage.components import Components
 from kbcstorage.configurations import Configurations
 
 from queue_v1_client import KeboolaClientQueueV1, KeboolaClientQueueV1Exception
-from queue_v2_client import KeboolaClientQueueV2, KeboolaClientQueueV2Exception
+from queue_v2_client import KeboolaClientQueueV2, KeboolaClientQueueV2Exception, KeboolaClientQueueV2ResponseError
 
 
 class Component(ComponentBase):
@@ -76,6 +76,14 @@ class Component(ComponentBase):
     def run_component_job(self, component_id: str, config_id: str, variables: Optional[Dict] = None) -> Dict:
         try:
             return self.client_v2.run_job(component_id, config_id, variables)
+        except KeboolaClientQueueV2ResponseError as response_exc:
+            # Not routed to the Queue V1 fallback on purpose: the request may already have started a
+            # job, and retrying it would start a second one.
+            raise UserException(
+                f"Could not read the Keboola Queue API reply when starting the job of component "
+                f"'{component_id}'. This is usually a temporary problem, re-run the configuration. "
+                f"\n\n{response_exc}"
+            ) from response_exc
         except KeboolaClientQueueV2Exception as v2_exc:
             try:
                 return self.client_v1.run_job(component_id, config_id, variables)
@@ -97,6 +105,13 @@ class Component(ComponentBase):
     def wait_until_job_finished(self, job_id):
         try:
             return self.client_v2.wait_until_job_finished(job_id)
+        except KeboolaClientQueueV2ResponseError as response_exc:
+            # Not routed to the Queue V1 fallback on purpose: a job that the V1 API cannot report on
+            # would otherwise be treated as if its status had been read successfully.
+            raise UserException(
+                f"Could not read the Keboola Queue API reply while monitoring job ID {job_id}. "
+                f"This is usually a temporary problem, re-run the configuration.\n\n{response_exc}"
+            ) from response_exc
         except KeboolaClientQueueV2Exception as v2_exc:
             try:
                 return self.client_v1.wait_until_job_finished(job_id)

--- a/src/queue_v2_client/__init__.py
+++ b/src/queue_v2_client/__init__.py
@@ -1,1 +1,5 @@
-from .client import KeboolaClientQueueV2, KeboolaClientQueueV2Exception  # noqa
+from .client import (  # noqa
+    KeboolaClientQueueV2,
+    KeboolaClientQueueV2Exception,
+    KeboolaClientQueueV2ResponseError,
+)

--- a/src/queue_v2_client/client.py
+++ b/src/queue_v2_client/client.py
@@ -17,6 +17,38 @@ class KeboolaClientQueueV2Exception(Exception):
     pass
 
 
+class KeboolaClientQueueV2ResponseError(Exception):
+    """The Queue API replied with a body that could not be read as a JSON object.
+
+    Deliberately NOT a subclass of KeboolaClientQueueV2Exception. That exception tells the caller to
+    retry the operation against the legacy Queue V1 API, which for a job start request would start a
+    second job. An unreadable reply gives no way to tell whether the request already took effect, so
+    it must end the run rather than be retried.
+    """
+
+
+def _loads_json_object(text: Optional[str]) -> Optional[Dict]:
+    """Parse text as a JSON object. Returns None if it is not valid JSON, or not a JSON object.
+
+    RecursionError and UnicodeDecodeError are included because a hostile or broken reply should not
+    be able to end the run with an unhandled exception through this function either.
+    """
+    try:
+        parsed = json.loads(text)
+    except (json.JSONDecodeError, TypeError, RecursionError, UnicodeDecodeError):
+        return None
+    return parsed if isinstance(parsed, dict) else None
+
+
+def _summarise_body(text: Optional[str], limit: int = 200) -> str:
+    """Collapse a reply body into a short single-line excerpt for an error message."""
+    if not text:
+        return "<empty>"
+    # Slice before normalising - an error page can be megabytes and only the excerpt is reported.
+    collapsed = " ".join(text[: limit * 10].split())
+    return collapsed[:limit] if collapsed else "<no printable content>"
+
+
 class KeboolaClientQueueV2(HttpClient):
     def __init__(self, sapi_token: str, keboola_stack: str, custom_cloud_stack: Optional[str]) -> None:
         """
@@ -55,7 +87,7 @@ class KeboolaClientQueueV2(HttpClient):
 
         response = self.post_raw(endpoint_path="jobs", headers=header, data=json.dumps(data))
         self._handle_http_error(response)
-        return json.loads(response.text)
+        return self._parse_json_body(response, "reply to a job start request")
 
     def wait_until_job_finished(self, job_id: str) -> str:
         is_finished = False
@@ -63,14 +95,14 @@ class KeboolaClientQueueV2(HttpClient):
             try:
                 response = self.get_raw(endpoint_path=f"jobs/{job_id}")
                 self._handle_http_error(response)
-                is_finished = json.loads(response.text).get("isFinished")
+                is_finished = self._parse_json_body(response, "job status reply").get("isFinished")
             except HTTPError as http_err:
                 raise KeboolaClientQueueV2Exception(http_err) from http_err
             time.sleep(10)
         try:
             response = self.get_raw(endpoint_path=f"jobs/{job_id}")
             self._handle_http_error(response)
-            return json.loads(response.text).get("status")
+            return self._parse_json_body(response, "job status reply").get("status")
         except HTTPError as http_err:
             raise KeboolaClientQueueV2Exception(http_err) from http_err
 
@@ -79,10 +111,35 @@ class KeboolaClientQueueV2(HttpClient):
         try:
             response.raise_for_status()
         except requests.HTTPError as e:
-            response_error = json.loads(e.response.text)
+            # An HTTP error reply is not guaranteed to carry a JSON object body: gateways and proxies
+            # answer 5xx with an HTML page, and some errors come back with an empty body. Parsing
+            # such a body used to raise a bare json.JSONDecodeError, which no caller handles, so the
+            # run ended as an opaque internal error instead of a message the user can act on.
+            response_error = _loads_json_object(e.response.text)
+            if response_error is None:
+                raise KeboolaClientQueueV2ResponseError(
+                    f"The Keboola Queue API returned HTTP {e.response.status_code} with an "
+                    f"unexpected error body: {_summarise_body(e.response.text)}"
+                ) from e
             raise KeboolaClientQueueV2Exception(
                 f"{response_error.get('error')}. Exception code {response_error.get('code')}"
             ) from e
+
+    @staticmethod
+    def _parse_json_body(response, description: str) -> Dict:
+        """Read a reply body that is expected to be a JSON object.
+
+        Guards the same defect as _handle_http_error: an unreadable body used to leak a
+        json.JSONDecodeError (or an AttributeError, for valid JSON that is not an object) as an
+        unhandled internal error.
+        """
+        parsed = _loads_json_object(response.text)
+        if parsed is None:
+            raise KeboolaClientQueueV2ResponseError(
+                f"The Keboola Queue API returned HTTP {response.status_code} with an unexpected "
+                f"{description}: {_summarise_body(response.text)}"
+            )
+        return parsed
 
     # override to continue on failure
     def _requests_retry_session(self, session=None):

--- a/tests/test_component_error_handling.py
+++ b/tests/test_component_error_handling.py
@@ -1,0 +1,93 @@
+"""Tests for how Component maps Queue client failures onto exit codes.
+
+The component exits 1 for a UserException and 2 for anything else. Exit 2 is an internal error: it
+pages the team and shows the user nothing useful. These tests pin which failures reach the user as a
+UserException, and - just as importantly - that an unreadable Queue V2 reply is NOT retried against
+the Queue V1 API, because a retried job start request would start a second job.
+"""
+
+import unittest
+
+import mock
+from keboola.component.exceptions import UserException
+
+from component import Component
+from queue_v1_client import KeboolaClientQueueV1Exception
+from queue_v2_client import KeboolaClientQueueV2Exception, KeboolaClientQueueV2ResponseError
+
+
+def _component_with_mock_clients() -> Component:
+    """Build a Component with both Queue clients mocked, bypassing the Keboola data dir."""
+    component = Component.__new__(Component)
+    component.client_v1 = mock.MagicMock()
+    component.client_v2 = mock.MagicMock()
+    return component
+
+
+class TestRunComponentJob(unittest.TestCase):
+
+    def test_returns_v2_payload_on_success(self):
+        component = _component_with_mock_clients()
+        component.client_v2.run_job.return_value = {"id": "1"}
+        self.assertEqual({"id": "1"}, component.run_component_job("keboola.some-component", "2"))
+        component.client_v1.run_job.assert_not_called()
+
+    def test_unreadable_v2_reply_raises_user_exception_without_touching_v1(self):
+        """The job must still fail - but as a user error, and without starting a second job."""
+        component = _component_with_mock_clients()
+        component.client_v2.run_job.side_effect = KeboolaClientQueueV2ResponseError("HTTP 502, unreadable")
+        with self.assertRaises(UserException) as ctx:
+            component.run_component_job("keboola.some-component", "2")
+        component.client_v1.run_job.assert_not_called()
+        self.assertIn("keboola.some-component", str(ctx.exception))
+        self.assertIn("HTTP 502, unreadable", str(ctx.exception))
+
+    def test_v2_client_exception_still_falls_back_to_v1(self):
+        component = _component_with_mock_clients()
+        component.client_v2.run_job.side_effect = KeboolaClientQueueV2Exception("boom")
+        component.client_v1.run_job.return_value = {"id": "3"}
+        self.assertEqual({"id": "3"}, component.run_component_job("keboola.some-component", "2"))
+        component.client_v1.run_job.assert_called_once()
+
+    def test_both_clients_failing_still_raises_user_exception(self):
+        component = _component_with_mock_clients()
+        component.client_v2.run_job.side_effect = KeboolaClientQueueV2Exception("v2 boom")
+        component.client_v1.run_job.side_effect = KeboolaClientQueueV1Exception("v1 boom")
+        with self.assertRaises(UserException):
+            component.run_component_job("keboola.some-component", "2")
+
+
+class TestWaitUntilJobFinished(unittest.TestCase):
+
+    def test_returns_status_on_success(self):
+        component = _component_with_mock_clients()
+        component.client_v2.wait_until_job_finished.return_value = "success"
+        self.assertEqual("success", component.wait_until_job_finished("4"))
+        component.client_v1.wait_until_job_finished.assert_not_called()
+
+    def test_unreadable_v2_reply_raises_user_exception_without_touching_v1(self):
+        component = _component_with_mock_clients()
+        component.client_v2.wait_until_job_finished.side_effect = KeboolaClientQueueV2ResponseError("HTTP 502")
+        with self.assertRaises(UserException) as ctx:
+            component.wait_until_job_finished("4")
+        component.client_v1.wait_until_job_finished.assert_not_called()
+        self.assertIn("job ID 4", str(ctx.exception))
+        self.assertIn("HTTP 502", str(ctx.exception))
+
+    def test_v2_client_exception_still_falls_back_to_v1(self):
+        component = _component_with_mock_clients()
+        component.client_v2.wait_until_job_finished.side_effect = KeboolaClientQueueV2Exception("boom")
+        component.client_v1.wait_until_job_finished.return_value = "success"
+        self.assertEqual("success", component.wait_until_job_finished("4"))
+        component.client_v1.wait_until_job_finished.assert_called_once()
+
+    def test_both_clients_failing_still_raises_user_exception(self):
+        component = _component_with_mock_clients()
+        component.client_v2.wait_until_job_finished.side_effect = KeboolaClientQueueV2Exception("v2 boom")
+        component.client_v1.wait_until_job_finished.side_effect = KeboolaClientQueueV1Exception("v1 boom")
+        with self.assertRaises(UserException):
+            component.wait_until_job_finished("4")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_queue_v2_client.py
+++ b/tests/test_queue_v2_client.py
@@ -1,0 +1,156 @@
+"""Tests for how the Queue V2 client reads Queue API replies.
+
+Every unreadable reply must surface as KeboolaClientQueueV2ResponseError. Before that existed, an
+error page or an empty body made json.loads raise a bare json.JSONDecodeError which no caller
+handled, so the run ended as an opaque internal error.
+"""
+
+import json
+import unittest
+from http import HTTPStatus
+
+import mock
+import requests
+
+from queue_v2_client import (
+    KeboolaClientQueueV2,
+    KeboolaClientQueueV2Exception,
+    KeboolaClientQueueV2ResponseError,
+)
+
+NOT_JSON_OBJECT_BODIES = {
+    "html error page": "<html>\n<head><title>502 Bad Gateway</title></head>\n</html>",
+    "empty body": "",
+    "whitespace only": "   \n\t ",
+    "plain text": "Bad Gateway",
+    "json null": "null",
+    "json list": "[1, 2, 3]",
+    "json string": '"a string"',
+    "json number": "42",
+    "truncated json": '{"id": "123"',
+}
+
+
+def _response(status_code: int, text: str) -> requests.Response:
+    """Build a minimal requests.Response with the given status code and raw body."""
+    response = requests.Response()
+    response.status_code = status_code
+    response.reason = HTTPStatus(status_code).phrase
+    response.url = "https://queue.keboola.com/jobs"
+    response._content = text.encode("utf-8")
+    return response
+
+
+class TestHandleHttpError(unittest.TestCase):
+    """_handle_http_error must never let a parse error escape.
+
+    A JSON object error body keeps raising KeboolaClientQueueV2Exception, which is what makes the
+    caller fall back to the Queue V1 API. Anything else raises KeboolaClientQueueV2ResponseError,
+    which deliberately does not trigger that fallback.
+    """
+
+    def test_success_reply_does_not_raise(self):
+        for status in (200, 201, 204):
+            with self.subTest(status=status):
+                KeboolaClientQueueV2._handle_http_error(_response(status, json.dumps({"id": "123"})))
+
+    def test_json_object_error_body_keeps_existing_message(self):
+        body = json.dumps({"error": "Configuration not found", "code": 404})
+        with self.assertRaises(KeboolaClientQueueV2Exception) as ctx:
+            KeboolaClientQueueV2._handle_http_error(_response(404, body))
+        self.assertEqual("Configuration not found. Exception code 404", str(ctx.exception))
+        self.assertNotIsInstance(ctx.exception, KeboolaClientQueueV2ResponseError)
+
+    def test_json_object_error_body_without_expected_keys_keeps_existing_message(self):
+        with self.assertRaises(KeboolaClientQueueV2Exception) as ctx:
+            KeboolaClientQueueV2._handle_http_error(_response(500, json.dumps({"unexpected": 1})))
+        self.assertEqual("None. Exception code None", str(ctx.exception))
+
+    def test_unreadable_error_body_raises_response_error(self):
+        """Regression for the reported failure: json.JSONDecodeError must not escape this handler."""
+        for label, body in NOT_JSON_OBJECT_BODIES.items():
+            with self.subTest(body=label):
+                with self.assertRaises(KeboolaClientQueueV2ResponseError) as ctx:
+                    KeboolaClientQueueV2._handle_http_error(_response(502, body))
+                self.assertNotIsInstance(ctx.exception, json.JSONDecodeError)
+                self.assertNotIsInstance(ctx.exception, KeboolaClientQueueV2Exception)
+                self.assertIn("HTTP 502", str(ctx.exception))
+
+    def test_empty_error_body_is_reported_as_empty(self):
+        with self.assertRaises(KeboolaClientQueueV2ResponseError) as ctx:
+            KeboolaClientQueueV2._handle_http_error(_response(503, ""))
+        self.assertIn("<empty>", str(ctx.exception))
+
+    def test_blank_error_body_is_not_reported_as_empty(self):
+        with self.assertRaises(KeboolaClientQueueV2ResponseError) as ctx:
+            KeboolaClientQueueV2._handle_http_error(_response(503, "   \n\t "))
+        self.assertIn("<no printable content>", str(ctx.exception))
+
+    def test_long_error_body_excerpt_is_capped(self):
+        with self.assertRaises(KeboolaClientQueueV2ResponseError) as ctx:
+            KeboolaClientQueueV2._handle_http_error(_response(500, "x" * 5_000_000))
+        message = str(ctx.exception)
+        self.assertIn("x" * 200, message)
+        self.assertNotIn("x" * 201, message)
+
+
+class TestParseJsonBody(unittest.TestCase):
+    """A 2xx reply whose body is not a JSON object must also fail as a response error."""
+
+    def test_json_object_is_returned_unchanged(self):
+        payload = {"id": "123", "isFinished": False, "status": "processing"}
+        parsed = KeboolaClientQueueV2._parse_json_body(_response(200, json.dumps(payload)), "reply")
+        self.assertEqual(payload, parsed)
+
+    def test_unreadable_body_raises_response_error(self):
+        for label, body in NOT_JSON_OBJECT_BODIES.items():
+            with self.subTest(body=label):
+                with self.assertRaises(KeboolaClientQueueV2ResponseError):
+                    KeboolaClientQueueV2._parse_json_body(_response(200, body), "reply")
+
+
+class TestClientMethods(unittest.TestCase):
+    """The same guarantee through the public methods, with the HTTP layer mocked out."""
+
+    def setUp(self):
+        self.client = KeboolaClientQueueV2("token", "", "")
+
+    def test_run_job_returns_payload_on_success(self):
+        reply = _response(201, json.dumps({"id": "789"}))
+        with mock.patch.object(KeboolaClientQueueV2, "post_raw", return_value=reply):
+            self.assertEqual({"id": "789"}, self.client.run_job("keboola.some-component", "1", None))
+
+    def test_run_job_raises_response_error_on_empty_success_body(self):
+        with mock.patch.object(KeboolaClientQueueV2, "post_raw", return_value=_response(200, "")):
+            with self.assertRaises(KeboolaClientQueueV2ResponseError):
+                self.client.run_job("keboola.some-component", "1", None)
+
+    def test_run_job_raises_response_error_on_html_error_body(self):
+        reply = _response(502, "<html><body>502 Bad Gateway</body></html>")
+        with mock.patch.object(KeboolaClientQueueV2, "post_raw", return_value=reply):
+            with self.assertRaises(KeboolaClientQueueV2ResponseError):
+                self.client.run_job("keboola.some-component", "1", None)
+
+    def test_wait_until_job_finished_returns_status_on_success(self):
+        replies = [
+            _response(200, json.dumps({"isFinished": True})),
+            _response(200, json.dumps({"status": "success"})),
+        ]
+        with mock.patch.object(KeboolaClientQueueV2, "get_raw", side_effect=replies):
+            with mock.patch("queue_v2_client.client.time.sleep"):
+                self.assertEqual("success", self.client.wait_until_job_finished("789"))
+
+    def test_wait_until_job_finished_raises_response_error_on_html_body(self):
+        reply = _response(200, "<html><body>gateway</body></html>")
+        with mock.patch.object(KeboolaClientQueueV2, "get_raw", return_value=reply):
+            with mock.patch("queue_v2_client.client.time.sleep"):
+                with self.assertRaises(KeboolaClientQueueV2ResponseError):
+                    self.client.wait_until_job_finished("789")
+
+    def test_invalid_stack_raises_client_exception(self):
+        with self.assertRaises(KeboolaClientQueueV2Exception):
+            KeboolaClientQueueV2("token", "not-a-stack.", "")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What happened

A production run of `kds-team.app-component-runner` (image tag **1.0.5**) ended with an opaque
**internal error, exit code 2**, reporting only:

```
json.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```

The run had already started and successfully completed five downstream component jobs. The sixth
job-start request came back from the Queue V2 API with a body that was not JSON, and `json.loads`
on that body raised out of the client.

The crash sits between two of the component's own log lines — `Running job of component '...' with
variables {...}` (`src/component.py:45`) and `Job execution started with job ID ...`
(`src/component.py:64`) — so it happened inside `client_v2.run_job()`. No traceback was captured,
so the exact one of the four `json.loads` call sites in `src/queue_v2_client/client.py` is not
known from telemetry; this PR guards all four, so it does not matter which fired.

## Why it paged the team instead of telling the user

`json.JSONDecodeError` is not a `KeboolaClientQueueV2Exception`, so it bypassed **all** of the
caller's error handling in `src/component.py` and reached the entrypoint's generic
`except Exception` → `exit(2)`. Exit 2 is an internal error: it alerts the team and shows the
customer nothing actionable, even though the real cause was a transient upstream reply.

## The fix

All four places the Queue V2 client parsed a reply body now go through a single guard:

- `_loads_json_object()` — parses, returning `None` for anything that is not a JSON **object**
  (covers a non-JSON body *and* valid JSON that is a list/null/string/number, which used to raise
  `AttributeError` from the following `.get()`).
- `_summarise_body()` — a single-line, 200-character excerpt for the error message, sliced before
  normalising so a multi-megabyte error page costs nothing.
- `_parse_json_body()` and `_handle_http_error()` raise **`KeboolaClientQueueV2ResponseError`**
  carrying the HTTP status and that excerpt.
- `src/component.py` converts it to a `UserException` → **exit 1** with a message the customer can
  act on.

### The one design decision worth reviewing

`KeboolaClientQueueV2ResponseError` is **deliberately not a subclass of
`KeboolaClientQueueV2Exception`**.

That exception is the signal that makes the caller retry the operation against the legacy Queue V1
API. An unreadable reply to a *job start* request gives no way to tell whether the job was already
created, so routing it into the V1 fallback could start a **second** downstream job. An earlier
draft of this fix did exactly that, and verification showed a run that previously exited 2 after 5
jobs would instead exit 0 after starting 8 — three downstream jobs that never previously ran. That
draft was rejected; hence the separate exception type.

The run still fails. It now fails legibly, and starts exactly the same jobs it did before.

## Behaviour impact: none — defensive-only

| Situation | Before | After |
|---|---|---|
| 2xx with a JSON object body | returns the payload | identical |
| HTTP error with a JSON object body | `KeboolaClientQueueV2Exception` → Queue V1 fallback | **identical**, byte-for-byte same message |
| HTTP error with an HTML / empty / non-object body | exit 2, opaque internal error | exit 1, `UserException` with status + excerpt |
| 2xx with an HTML / empty / non-object body | exit 2, opaque internal error | exit 1, `UserException` with status + excerpt |

- No line of the diff is reachable on a 2xx reply carrying a JSON object.
- Every changed path already ended the run; none of them can now return, continue, or produce an
  empty or partial result.
- Downstream job counts are unchanged in every scenario.
- No existing test assertion was modified or deleted.

## Verification

An independent fresh-context reviewer A/B'd both versions of `_handle_http_error` across 9 status
codes x 6 JSON-object bodies (zero differences in exception type, message, or `__cause__`), drove
`Component.run_job` over 8 rows against a fake HTTP layer under 18 fault scenarios comparing exit
code *and* downstream jobs started against `master` (every difference was exit 2 → exit 1; job
counts identical in all 18), and mutation-tested the change with 8 mutants — including reverting to
the rejected "subclass `KeboolaClientQueueV2Exception`" design. **All 8 mutants were killed.**

The new tests were also confirmed to fail against the pre-fix source, reproducing the incident's
exact exception:
`json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)` at
`src/queue_v2_client/client.py:82`.

CI-equivalent commands, run in the component image:

```
$ docker run --rm <image> flake8 . --config=flake8.cfg
(no output, exit 0)

$ docker run --rm <image> python -m unittest discover
........................
----------------------------------------------------------------------
Ran 24 tests in 0.047s

OK
```

## Known follow-up, deliberately out of scope

`src/queue_v1_client/client.py` has the same class of defect: it calls `self.post()`/`self.get()`,
which parse via `keboola.http_client`'s `r.json()`, raising
`requests.exceptions.JSONDecodeError` — which its local `except HTTPError` does not catch, so it
also escapes as exit 2. That path is only reachable as the fallback *after* a Queue V2 HTTP error
with a valid JSON body, and it is not made worse by this PR, so it is left for a separate change
rather than widening this one.
